### PR TITLE
require jQuery as a peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "dependencies": {
+  "peerDependencies": {
     "jquery": ">= 1.3.0"
   },
   "keywords": [


### PR DESCRIPTION
https://nodejs.org/en/blog/npm/peer-dependencies/#the-problem-plugins

because we're plugging into jQuery we should use the parents' module's jQuery not our own.
